### PR TITLE
Feature/SOF-7337 feature: add functions from NBs

### DIFF
--- a/src/py/mat3ra/made/tools/analyze.py
+++ b/src/py/mat3ra/made/tools/analyze.py
@@ -39,3 +39,19 @@ def calculate_average_interlayer_distance(
     # Calculate the average distance between the top layer of substrate and the bottom layer of film
     average_interlayer_distance = avg_z_bottom_film - avg_z_top_substrate
     return abs(average_interlayer_distance)
+
+
+@convert_material_args_kwargs_to_atoms
+def calculate_surface_area(atoms: Atoms):
+    """
+    Calculate the area of the surface perpendicular to the z-axis of the atoms structure.
+
+    Args:
+        atoms (ase.Atoms): The Atoms object to calculate the surface area of.
+
+    Returns:
+        float: The surface area of the atoms.
+    """
+    matrix = atoms.cell
+    cross_product = np.cross(matrix[0], matrix[1])
+    return np.linalg.norm(cross_product)

--- a/tests/py/unit/test_tools_analyze.py
+++ b/tests/py/unit/test_tools_analyze.py
@@ -1,6 +1,7 @@
 import numpy as np
-from ase.build import bulk
+from ase.build import bulk, surface
 from mat3ra.made.tools.analyze import calculate_average_interlayer_distance
+from mat3ra.made.tools.analyze import calculate_surface_area
 
 
 def test_calculate_average_interlayer_distance():
@@ -10,3 +11,9 @@ def test_calculate_average_interlayer_distance():
     interface_atoms.set_tags([1] * len(substrate) + [2] * len(film))
     distance = calculate_average_interlayer_distance(interface_atoms, 1, 2)
     assert np.isclose(distance, 4.0725)
+
+
+def test_calculate_surface_area():
+    atoms = bulk("Si", cubic=False)
+    area = calculate_surface_area(atoms)
+    assert np.isclose(area, 12.7673)


### PR DESCRIPTION
Adds functions from other/materials_designer NBs to made-tools:
calc_total_energy_per_atom, 
calc_surface_energy, 
calc_adhesion_energy,
 calc_interfacial_energy,
surface area,
translate_to_bottom*

Rewrites to_ase and from_ase natively (no AseAdapter)