### PR TITLE
fix: get the coordinate of the nearest atom

### DIFF
--- a/src/py/mat3ra/made/tools/build/defect/configuration.py
+++ b/src/py/mat3ra/made/tools/build/defect/configuration.py
@@ -19,18 +19,16 @@ class PointDefectConfiguration(BaseDefectConfiguration, InMemoryEntity):
     chemical_element: Optional[str] = None
 
     @classmethod
-    def from_site_id(cls, site_id: int, crystal: Material):
+    def from_site_id(
+        cls, crystal: Material, defect_type: PointDefectTypeEnum, site_id: int, chemical_element: Optional[str] = None
+    ):
         if not crystal:
             RuntimeError("Crystal is not defined")
-        position = crystal.coordinates_array[site_id]            
-        return cls(crystal=crystal, position=position)
+        position = crystal.coordinates_array[site_id]
+        return cls(crystal=crystal, defect_type=defect_type, position=position, chemical_element=chemical_element)
 
     @classmethod
-    def from_approximate_position(
-        cls,
-        approximate_position: List[float],
-        crystal: Material
-    ):
+    def from_approximate_position(cls, approximate_position: List[float], crystal: Material):
         if not crystal:
             RuntimeError("Crystal is not defined")
         closest_site_id = get_closest_site_id_from_position(crystal, approximate_position)

--- a/src/py/mat3ra/made/tools/build/defect/configuration.py
+++ b/src/py/mat3ra/made/tools/build/defect/configuration.py
@@ -24,7 +24,11 @@ class PointDefectConfiguration(BaseDefectConfiguration, InMemoryEntity):
         # Pymatgen accepts the coordinate of the atom within small tolerance
         if site_id is None:
             self.site_id = get_closest_site_id_from_position(self.crystal, position)
-            self.position = self.crystal.coordinates_array[self.site_id]
+            self.position = (
+                position
+                if data["defect_type"] == PointDefectTypeEnum.INTERSTITIAL
+                else self.crystal.coordinates_array[self.site_id]
+            )
         else:
             self.position = self.crystal.coordinates_array[site_id]
 

--- a/src/py/mat3ra/made/tools/build/defect/configuration.py
+++ b/src/py/mat3ra/made/tools/build/defect/configuration.py
@@ -21,10 +21,12 @@ class PointDefectConfiguration(BaseDefectConfiguration, InMemoryEntity):
 
     def __init__(self, position=position, site_id=None, **data):
         super().__init__(**data)
-        if site_id is not None:
-            self.position = self.crystal.coordinates_array[site_id]
-        else:
+        # Pymatgen accepts the coordinate of the atom within small tolerance
+        if site_id is None:
             self.site_id = get_closest_site_id_from_position(self.crystal, position)
+            self.position = self.crystal.coordinates_array[self.site_id]
+        else:
+            self.position = self.crystal.coordinates_array[site_id]
 
     @classmethod
     def from_site_id(cls, site_id: int, crystal: Material, **data):

--- a/src/py/mat3ra/made/tools/build/defect/configuration.py
+++ b/src/py/mat3ra/made/tools/build/defect/configuration.py
@@ -19,19 +19,22 @@ class PointDefectConfiguration(BaseDefectConfiguration, InMemoryEntity):
     chemical_element: Optional[str] = None
 
     @classmethod
-    def from_site_id(cls, site_id: int, crystal: Material, **data):
-        if crystal:
-            position = crystal.coordinates_array[site_id]
-        else:
+    def from_site_id(cls, site_id: int, crystal: Material):
+        if not crystal:
             RuntimeError("Crystal is not defined")
-        return cls(crystal=crystal, position=position, **data)
+        position = crystal.coordinates_array[site_id]            
+        return cls(crystal=crystal, position=position)
 
+    @classmethod
     def from_approximate_position(
-        self,
+        cls,
         approximate_position: List[float],
+        crystal: Material
     ):
-        closest_site_id = get_closest_site_id_from_position(self.crystal, approximate_position)
-        self.position = self.crystal.coordinates_array[closest_site_id]
+        if not crystal:
+            RuntimeError("Crystal is not defined")
+        closest_site_id = get_closest_site_id_from_position(crystal, approximate_position)
+        return cls.from_site_id(closest_site_id, crystal)
 
     @property
     def _json(self):

--- a/src/py/mat3ra/made/tools/build/defect/configuration.py
+++ b/src/py/mat3ra/made/tools/build/defect/configuration.py
@@ -28,11 +28,19 @@ class PointDefectConfiguration(BaseDefectConfiguration, InMemoryEntity):
         return cls(crystal=crystal, defect_type=defect_type, position=position, chemical_element=chemical_element)
 
     @classmethod
-    def from_approximate_position(cls, approximate_position: List[float], crystal: Material):
+    def from_approximate_position(
+        cls,
+        crystal: Material,
+        defect_type: PointDefectTypeEnum,
+        approximate_position: List[float],
+        chemical_element: Optional[str] = None,
+    ):
         if not crystal:
             RuntimeError("Crystal is not defined")
         closest_site_id = get_closest_site_id_from_position(crystal, approximate_position)
-        return cls.from_site_id(closest_site_id, crystal)
+        return cls.from_site_id(
+            crystal=crystal, defect_type=defect_type, site_id=closest_site_id, chemical_element=chemical_element
+        )
 
     @property
     def _json(self):

--- a/src/py/mat3ra/made/tools/build/interface/builders.py
+++ b/src/py/mat3ra/made/tools/build/interface/builders.py
@@ -159,6 +159,7 @@ class ZSLStrainMatchingInterfaceBuilder(ConvertGeneratedItemsPymatgenStructureMi
         interfaces = builder.get_interfaces(
             termination=termination_pair.to_pymatgen(),
             gap=configuration.distance_z,
+            vacuum_over_film=configuration.vacuum,
             film_thickness=configuration.film_configuration.thickness,
             substrate_thickness=configuration.substrate_configuration.thickness,
             in_layers=True,


### PR DESCRIPTION
Had to fix the position of the nearest atom so that it doesn't fail in nbs -- the problem that I had while making the videos.
We return position, which pymatgen accepts. Previously we returned not a position of the atom within tolerance, but a provided one, which is arbitrary
